### PR TITLE
Added Config File Feature

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "python.analysis.autoImportCompletions": true
-}

--- a/README.md
+++ b/README.md
@@ -44,6 +44,19 @@ pyrcedit "path-to-file.exe" [options...]
 
 > **Note:** PyRcEdit required full path to your executable file. Don't provide just a name even you are in the same folder as file. Otherwise you'll get `fatal error : Unable to commit change error`. Just give full path to exe file as in example.
 
+### Directory Mode (Configuration File)
+
+If you find yourself running the same commands frequently, you can run PyRcEdit against a directory (for example, `.`) instead of an executable. PyRcEdit will look for a `pyrcedit.prec` file in the target directory and execute the arguments contained within it.
+
+```bash
+pyrcedit .
+```
+
+Example `pyrcedit.prec` contents:
+```
+"E:\MyFile\app.exe" --set-product-version 1.0.0.0 --set-icon "app.ico"
+```
+
 ---
 
 ## 📖 Command Reference

--- a/pyrcedit.py
+++ b/pyrcedit.py
@@ -34,6 +34,7 @@ import argparse
 import copy
 import io
 from pathlib import Path
+import shlex
 
 # ── Win32 constants ──────────────────────────────────────────────────────────
 LOAD_LIBRARY_AS_DATAFILE = 0x00000002
@@ -872,6 +873,26 @@ def main(argv=None):
         PyRcEditRepo = "Official Github Repo - https://github.com/pixcapsoft/PyRcEdit\n\nFeel free to contribute & star the project\nBuilt By Ranuja Sanmira\nCopyright © 2026 PixCap Soft"
         print(PyRcEditRepo)
         return 0
+
+    if len(argv) == 1 and os.path.isdir(argv[0]):
+        target_dir = argv[0]
+        prec_path = os.path.join(target_dir, "pyrcedit.prec")
+        if os.path.exists(prec_path):
+            try:
+                with open(prec_path, "r", encoding="utf-8") as f:
+                    content = f.read()
+                
+                # If a specific local directory was passed, we should change the working dir to it
+                # so that relative paths in pyrcedit.prec are interpreted correctly.
+                os.chdir(target_dir)
+                
+                argv = shlex.split(content, posix=False)
+                if not argv:
+                    return fatal(f"Configuration file is empty: {prec_path}")
+            except Exception as e:
+                return fatal(f"Failed to read {prec_path}: {e}")
+        else:
+            return fatal(f"Configuration file not found: {prec_path}")
 
     updater = ResourceUpdater()
     loaded = False


### PR DESCRIPTION
# Added Config File Feature

If you find yourself running the same commands frequently, you can run PyRcEdit against a directory (for example, `.`) instead of an executable. PyRcEdit will look for a `pyrcedit.prec` file in the target directory and execute the arguments contained within it.

```bash
pyrcedit .
```

Example `pyrcedit.prec` contents:
```
"E:\MyFile\app.exe" --set-product-version 1.0.0.0 --set-icon "app.ico"
```